### PR TITLE
Add check for active Material Output node

### DIFF
--- a/bakelab_bake.py
+++ b/bakelab_bake.py
@@ -214,7 +214,11 @@ class Baker(Operator):
     def find_node(self, nodes, type):
         for node in nodes:
             if node.type == type:
-                return node
+                if type == "OUTPUT_MATERIAL":
+                    if node.is_active_output:
+                        return node
+                else:
+                    return node
         return None
     
     def get_socket(self, sockets, identifier):


### PR DESCRIPTION
Updates the find_node function to ensure that it returns the active Material Output node instead of the first one it finds, in case there are multiple Material Output nodes present.
This fixes #5.