### PR TITLE
Add 'Create Folder' checkbox

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -158,6 +158,16 @@ class BakeLabProperties(PropertyGroup):
                 ),
                 default = 'PACK'
             )
+    create_folder : BoolProperty(
+        name="Create folder",
+        description="Automatically creates a folder named after the object(s)",
+        default = True
+        ) 
+    folder_name  : StringProperty(
+            name = 'Folder name',
+            description = 'Name of the folder',
+            default = "Selection",
+        )
     save_path : StringProperty(
                 default=expanduser("~"),
                 name="Folder",

--- a/bakelab_bake.py
+++ b/bakelab_bake.py
@@ -16,7 +16,7 @@ from bpy.props import (
         )
 
 from math import log2
-from os.path import abspath, join
+from os.path import abspath, join, exists
 
 from .bakelab_tools import (
     SelectObject,
@@ -455,7 +455,13 @@ class Baker(Operator):
                 extension = '.jpg'
             if map.file_format == 'OPEN_EXR':
                 extension = '.exr'
-            bake_image.filepath = abspath(join(props.save_path, bake_image.name + extension))
+            if props.create_folder:
+                if props.bake_mode == "ALL_TO_ONE":
+                    bake_image.filepath = abspath(join(props.save_path, props.folder_name, bake_image.name + extension))
+                else:
+                    bake_image.filepath = abspath(join(props.save_path, name, bake_image.name + extension))
+            else:
+                bake_image.filepath = abspath(join(props.save_path, bake_image.name + extension))
             
             bake_image.save_render(bake_image.filepath)
         

--- a/bakelab_ui.py
+++ b/bakelab_ui.py
@@ -72,9 +72,11 @@ class BakeLabUI(Panel):
             layout.use_property_split = False
             if props.save_or_pack == "SAVE":
                 layout.prop(props, "save_path")
+                layout.prop(props, "create_folder")
+                if props.bake_mode == "ALL_TO_ONE":
+                    layout.prop(props, "folder_name")
             else:
                 layout.label(text = "")
-            
             col = layout.column()
             col.label(text = "Maps:")
             box = col.box()


### PR DESCRIPTION
Added the possibility to automatically create folders to save baked images. 
This is particularly useful when dealing with multiple maps and multiple objects. It also allows a clean file system or project folder structure.
A friend of mine, who's now using this modified version of the addon to create assets (game dev), suggested this feature.

When "Individual objects" is selected, it automatically creates folders with the same name of the objects.
When "All To One Image" is selected, it asks for a folder name (default="Selection").