### PR TITLE
Fix Issue #14 - Connect Normal Map Correctly

### DIFF
--- a/bakelab_post.py
+++ b/bakelab_post.py
@@ -86,7 +86,7 @@ class BakeLab_GenerateMaterials(Operator):
                 nmNode.location = -700, -500
                 nmNode.space = bake_map.normal_space
                 links.new(imgNode.outputs[0], nmNode.inputs[1])
-                links.new(nmNode.outputs[0], pbr.inputs[19])
+                links.new(nmNode.outputs[0], pbr.inputs[20])
                 links.new(uvm.outputs[2], imgNode.inputs[0])
                 pass_available = True
             if bake_map.type == 'AO':


### PR DESCRIPTION
When generating a material from baked textures, the normal map image is assigned to the Alpha BSDF node instead of the expected Normal Node. 

I'm guessing the BSDF node was updated by blender to include one more Node input, so that referring to the node input by index (19) broke. 

There is probably some more fundamental fix that can refer to node inputs by name, but that's not included here.