### PR TITLE
Fix UI redraw when used from command line

### DIFF
--- a/bakelab_bake.py
+++ b/bakelab_bake.py
@@ -871,7 +871,9 @@ class Baker(Operator):
 
         if event.type == 'TIMER':
             if context.scene.BakeLabProps.bake_state == 'BAKING':
-                context.area.tag_redraw() # Update UI
+                # Check if the area is valid and if it's the correct area type
+                if context.area and context.area.type == 'VIEW_3D':
+                    context.area.tag_redraw() # Update UI
             result = next(self.BakeCrt)
             if result == -1:
                 self.cancel(context)

--- a/bakelab_map.py
+++ b/bakelab_map.py
@@ -407,7 +407,9 @@ class BakeLabAddMapItem(bpy.types.Operator):
         return wm.invoke_props_dialog(self)
     
     def execute(self,context):
-        context.area.tag_redraw()
+        # Check if the area is valid and if it's the correct area type
+        if context.area and context.area.type == 'VIEW_3D':
+            context.area.tag_redraw()
         item = context.scene.BakeLabMaps.add()
         
         item.type        = self.type
@@ -442,7 +444,9 @@ class BakeLabRemoveMapItem(bpy.types.Operator):
         return context.scene.BakeLabMaps
     
     def execute(self,context):
-        context.area.tag_redraw()
+        # Check if the area is valid and if it's the correct area type
+        if context.area and context.area.type == 'VIEW_3D':
+            context.area.tag_redraw()
         context.scene.BakeLabMaps.remove(context.scene.BakeLabMapIndex)
         context.scene.BakeLabMapIndex = max(context.scene.BakeLabMapIndex - 1,0)
         context.scene.BakeLabMapIndex = min(context.scene.BakeLabMapIndex, len(context.scene.BakeLabMaps))
@@ -468,7 +472,9 @@ class BakeLabShowPassPresets(Operator):
         )
     
     def execute(self,context):
-        context.area.tag_redraw()
+        # Check if the area is valid and if it's the correct area type
+        if context.area and context.area.type == 'VIEW_3D':
+            context.area.tag_redraw()
         scene = context.scene
         if scene.BakeLabMapIndex>=0 and scene.BakeLabMaps:
             item = scene.BakeLabMaps[scene.BakeLabMapIndex]


### PR DESCRIPTION
added a check to ensure context.area is valid and of type VIEW_3D, to fix issues when executed from a python script via command line.

Preventing AttributeError: 'NoneType' object has no attribute 'tag_redraw'